### PR TITLE
Add missing response type to endpoint

### DIFF
--- a/wls-backend/Controllers/SubscriptionsController.cs
+++ b/wls-backend/Controllers/SubscriptionsController.cs
@@ -46,7 +46,7 @@ namespace wls_backend.Controllers
         }
 
         [HttpPut("{token}")]
-        public async Task<IActionResult> CreateOrUpdateSubscriptions([FromRoute] string token, [FromBody] UpdateSubscriptionsRequest request)
+        public async Task<ActionResult<SubscriptionResponse>> CreateOrUpdateSubscriptions([FromRoute] string token, [FromBody] UpdateSubscriptionsRequest request)
         {
             _logger.LogInformation("Attempting to create or update subscriptions for token.");
             try


### PR DESCRIPTION
Changed the return type of the `CreateOrUpdateSubscriptions` method from `Task<IActionResult>` to `Task<ActionResult<SubscriptionResponse>>` in `SubscriptionsController.cs` to ensure the endpoint returns a strongly-typed response and the swagger doc now shows it.